### PR TITLE
fix in hostname validation

### DIFF
--- a/check/check_nextcloud.py
+++ b/check/check_nextcloud.py
@@ -9,6 +9,7 @@
 ###############################################################################################################
 
 import urllib2, base64, xml.etree.ElementTree, sys, traceback
+import re
 
 # Some helper functions
 def calc_size_suffix(num, suffix='B'):
@@ -72,7 +73,8 @@ if not options.check:
 	sys.exit(3)
 
 # Re-validate the hostname given by the user (make sure they dont entered a "https://", "http://" or "/")
-hostname = options.hostname.lstrip('[https|http]://').split('/')[0]
+url_strip = re.compile(r"https?://")
+hostname = url_strip.sub('', options.hostname).split('/')[0]
 
 # Re-validate the api_url
 if options.api_url.startswith('/'):


### PR DESCRIPTION
Hi

I have found error in hostname validation. When hostname starts with letter from [https] list, then this letter was removed (and hostname was wrong)

```
>>> hostname="single.host.tld"
>>> hostname.lstrip('[https|http]://').split('/')[0]
'ingle.host.tld'
>>> hostname="triple.host.tld"
>>> hostname.lstrip('[https|http]://').split('/')[0]
'riple.host.tld'
>>> hostname="cloud.host.tld"
>>> hostname.lstrip('[https|http]://').split('/')[0]
'cloud.host.tld'
>>> hostname="poor.host.tld"
>>> hostname.lstrip('[https|http]://').split('/')[0]
'oor.host.tld'
```
There is small fix :)
